### PR TITLE
It's time for the big refactor

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -12,7 +12,6 @@
   let previousTrack;
   let currentTrack;
   let nextTrack;
-  let artist;
   let album;
   let albumUrl;
   let artwork;
@@ -48,17 +47,6 @@
       } else {
         nextTrack = undefined;
       }
-    }
-  }
-  $: {
-    // Since we don't know the album's main artist, treating the current
-    // artist as the album artist and change with each track
-    if (tracks === undefined) {
-      artist = undefined;
-    } else if (currentTrack === undefined) {
-      artist = tracks[startingTrack].artist;
-    } else {
-      artist = tracks[currentTrack].artist;
     }
   }
 
@@ -133,7 +121,7 @@
       {previousTrack}
       {nextTrack}
     />
-    <Tracklist {tracks} {currentTrack} {play} {artist} />
+    <Tracklist {tracks} {currentTrack} {play} />
     <Links {albumUrl} />
   {:catch _}
     {#if fallbackText && fallbackUrl}

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -4,12 +4,12 @@
   export let fallbackText;
   export let fallbackUrl;
 
-  import bandcampLogoColor from "./icons/bandcamp-logotype-color.png";
-  import bandcampLogoWhite from "./icons/bandcamp-logotype-white.png";
   import playIcon from "./icons/play.svg";
   import pauseIcon from "./icons/pause.svg";
   import previousIcon from "./icons/previous.svg";
   import nextIcon from "./icons/next.svg";
+
+  import Links from "./Links.svelte";
 
   let tracks;
   let startingTrack;
@@ -239,20 +239,7 @@
         </li>
       {/each}
     </ul>
-    <div class="links">
-      <a href={`${albumUrl}&action=buy`}>buy</a>
-      &nbsp;
-      <a href={`${albumUrl}&action=share`}>share</a>
-      <a class="logo" href={albumUrl}>
-        <picture>
-          <source
-            srcset={bandcampLogoWhite}
-            media="(prefers-color-scheme: dark)"
-          />
-          <img src={bandcampLogoColor} alt="Bandcamp logo" />
-        </picture>
-      </a>
-    </div>
+    <Links {albumUrl} />
   {:catch _}
     {#if fallbackText && fallbackUrl}
       <p style="margin: 16px;"><a href={fallbackUrl}>{fallbackText}</a></p>
@@ -358,23 +345,6 @@
     display: flex;
     justify-content: center;
     overflow: hidden;
-  }
-
-  .links {
-    height: 46px;
-    display: flex;
-    align-items: center;
-    justify-content: flex-end;
-  }
-  .links > *:first-child {
-    margin-right: 8px; /* fix space between buy/share links */
-  }
-  .links > .logo {
-    line-height: 0;
-  }
-  .links > .logo > picture > img {
-    height: 32px;
-    width: 110px;
   }
 
   .tracks {

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -10,6 +10,7 @@
   import nextIcon from "./icons/next.svg";
 
   import Links from "./Links.svelte";
+  import Tracklist from "./Tracklist.svelte";
 
   let tracks;
   let startingTrack;
@@ -213,32 +214,7 @@
         </div>
       </div>
     </div>
-    <ul class="tracks">
-      {#each tracks as track, i}
-        <li
-          tabindex={tracks[i].track_streaming ? 0 : -1}
-          class:now-playing={i === currentTrack}
-          class:unstreamable={!tracks[i].track_streaming}
-          on:click={() => tracks[i].track_streaming && play(i)}
-          on:keydown={(e) => {
-            if (tracks[i].track_streaming && e.key === " ") {
-              e.preventDefault();
-              play(i);
-            }
-          }}
-        >
-          <span>
-            {Math.floor(track.duration / 60)
-              .toString()
-              .padStart(2, " ")}:{Math.floor(track.duration % 60)
-              .toString()
-              .padStart(2, "0")}
-          </span>
-          {@html "  " + track.title}
-          {#if track.artist !== artist}– {track.artist}{/if}
-        </li>
-      {/each}
-    </ul>
+    <Tracklist {tracks} {currentTrack} {play} {artist} />
     <Links {albumUrl} />
   {:catch _}
     {#if fallbackText && fallbackUrl}
@@ -345,33 +321,5 @@
     display: flex;
     justify-content: center;
     overflow: hidden;
-  }
-
-  .tracks {
-    margin: 8px 0 0;
-    padding: 0;
-    height: 160px;
-    overflow-y: scroll;
-  }
-  .tracks > * {
-    font-size: 12px;
-    cursor: pointer;
-    margin: 0px 12px;
-    padding: 10px 8px;
-    list-style-type: none;
-    border-bottom: 1px solid #bbb;
-    white-space: pre;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-  .tracks > .now-playing {
-    font-weight: 700;
-  }
-  .tracks > .unstreamable {
-    cursor: default;
-    opacity: 0.5;
-  }
-  .tracks span {
-    font-family: monospace;
   }
 </style>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -4,13 +4,9 @@
   export let fallbackText;
   export let fallbackUrl;
 
-  import playIcon from "./icons/play.svg";
-  import pauseIcon from "./icons/pause.svg";
-  import previousIcon from "./icons/previous.svg";
-  import nextIcon from "./icons/next.svg";
-
   import Links from "./Links.svelte";
   import Tracklist from "./Tracklist.svelte";
+  import Player from "./Player.svelte";
 
   let tracks;
   let startingTrack;
@@ -154,66 +150,23 @@
 />
 <div class="root">
   {#await load() then _}
-    <div class="player">
-      <div class="artwork">
-        <img on:click={toggle} src={artwork} alt="Cover artwork for {album}" />
-      </div>
-      <div class="info">
-        <p>
-          <a href={albumUrl}>
-            {@html tracks[
-              currentTrack === undefined ? startingTrack : currentTrack
-            ].title}
-          </a>
-        </p>
-        <p>
-          {@html tracks[
-            currentTrack === undefined ? startingTrack : currentTrack
-          ].artist}
-        </p>
-        <p>{@html album}</p>
-        <div class="controls">
-          {#if paused || currentTrack === undefined}
-            <button
-              aria-label="Play current song"
-              on:click={() =>
-                play(currentTrack === undefined ? startingTrack : currentTrack)}
-            >
-              {@html playIcon}
-            </button>
-          {:else}
-            <button aria-label="Pause current song" on:click={pause}>
-              {@html pauseIcon}
-            </button>
-          {/if}
-          <input
-            aria-label="Seek"
-            type="range"
-            min="0"
-            max={currentTrack === undefined
-              ? undefined
-              : Math.floor(tracks[currentTrack].duration)}
-            value={(seekingTime === undefined ? currentTime : seekingTime) || 0}
-            on:change={handleSeeking}
-            on:input={handleSeeking}
-          />
-          <button
-            aria-label="Play previous song"
-            on:click={() => play(previousTrack)}
-            disabled={previousTrack === undefined}
-          >
-            {@html previousIcon}
-          </button>
-          <button
-            aria-label="Play next song"
-            on:click={() => play(nextTrack)}
-            disabled={nextTrack === undefined}
-          >
-            {@html nextIcon}
-          </button>
-        </div>
-      </div>
-    </div>
+    <Player
+      {toggle}
+      {artwork}
+      {album}
+      {albumUrl}
+      {tracks}
+      {currentTrack}
+      {startingTrack}
+      {paused}
+      {play}
+      {pause}
+      {seekingTime}
+      {currentTime}
+      {handleSeeking}
+      {previousTrack}
+      {nextTrack}
+    />
     <Tracklist {tracks} {currentTrack} {play} {artist} />
     <Links {albumUrl} />
   {:catch _}
@@ -240,86 +193,5 @@
   /* This interferes the SVGs inside buttons, ignore them */
   .root :global(:not(button *)) {
     all: revert;
-  }
-
-  button {
-    cursor: pointer;
-    opacity: 0.8;
-    color: inherit;
-    border: none;
-    background-color: unset;
-    padding: 4px;
-    line-height: 0;
-  }
-  button:hover {
-    opacity: 1;
-  }
-  button:disabled {
-    cursor: auto;
-    opacity: 0.5;
-  }
-  a {
-    color: #537d86;
-    text-decoration: underline;
-    font-weight: 700;
-  }
-  @media (prefers-color-scheme: dark) {
-    a {
-      color: inherit;
-    }
-  }
-
-  .player {
-    display: flex;
-    height: 120px;
-  }
-
-  .info {
-    flex: 1 1 0;
-    min-width: 198px;
-    padding: 12px 0 0;
-    width: 100%;
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between;
-    overflow: hidden;
-  }
-  .info p {
-    margin: 0 8px 0 12px;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-  .info > p:last-of-type {
-    font-style: italic;
-  }
-
-  .controls {
-    width: 100%;
-    box-sizing: border-box;
-    display: flex;
-    align-items: center;
-    padding-right: 4px; /* line up with links below */
-  }
-  .controls > *:first-child {
-    padding-left: 8px; /* keep space between play button/artwork interactive */
-  }
-  .controls > input {
-    cursor: grab;
-    flex-grow: 1;
-    width: 0; /* force smaller width on Firefox */
-  }
-  .controls > input:active {
-    cursor: grabbing;
-  }
-
-  .artwork {
-    cursor: pointer;
-    height: 120px;
-    width: 120px;
-    min-width: 80px;
-    display: flex;
-    justify-content: center;
-    overflow: hidden;
   }
 </style>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -148,4 +148,15 @@
   .root :global(:not(button *)) {
     all: revert;
   }
+
+  .root :global(a) {
+    color: #537d86;
+    text-decoration: underline;
+    font-weight: 700;
+  }
+  @media (prefers-color-scheme: dark) {
+    .root :global(a) {
+      color: inherit;
+    }
+  }
 </style>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -100,29 +100,6 @@
     audio.pause();
   }
 
-  function toggle() {
-    if (paused) {
-      play(currentTrack);
-    } else {
-      pause();
-    }
-  }
-
-  let seekingTime;
-  function handleSeeking(event) {
-    switch (event.type) {
-      case "change":
-        seek(event.target.value);
-        seekingTime = undefined;
-        break;
-      case "input":
-        seekingTime = event.target.value;
-        break;
-      default:
-        break;
-    }
-  }
-
   function seek(time) {
     // Seeking via currentTime is inconsistent in Firefox, seems to be a
     // regression of https://github.com/sveltejs/svelte/issues/3524
@@ -143,7 +120,6 @@
 <div class="root">
   {#await load() then _}
     <Player
-      {toggle}
       {artwork}
       {album}
       {albumUrl}
@@ -152,9 +128,8 @@
       paused={paused || /* unloaded audio shows as playing */ audio.src === ""}
       {play}
       {pause}
-      {seekingTime}
+      {seek}
       {currentTime}
-      {handleSeeking}
       {previousTrack}
       {nextTrack}
     />

--- a/src/Links.svelte
+++ b/src/Links.svelte
@@ -18,17 +18,6 @@
 </div>
 
 <style>
-  a {
-    color: #537d86;
-    text-decoration: none;
-    font-weight: 700;
-  }
-  @media (prefers-color-scheme: dark) {
-    a {
-      color: inherit;
-    }
-  }
-
   .links {
     height: 46px;
     display: flex;

--- a/src/Links.svelte
+++ b/src/Links.svelte
@@ -1,0 +1,51 @@
+<script>
+  export let albumUrl;
+
+  import bandcampLogoColor from "./icons/bandcamp-logotype-color.png";
+  import bandcampLogoWhite from "./icons/bandcamp-logotype-white.png";
+</script>
+
+<div class="links">
+  <a href={`${albumUrl}&action=buy`}>buy</a>
+  &nbsp;
+  <a href={`${albumUrl}&action=share`}>share</a>
+  <a class="logo" href={albumUrl}>
+    <picture>
+      <source srcset={bandcampLogoWhite} media="(prefers-color-scheme: dark)" />
+      <img src={bandcampLogoColor} alt="Bandcamp logo" />
+    </picture>
+  </a>
+</div>
+
+<style>
+  a {
+    color: #537d86;
+    text-decoration: none;
+    font-weight: 700;
+  }
+  @media (prefers-color-scheme: dark) {
+    a {
+      color: inherit;
+    }
+  }
+
+  .links {
+    height: 46px;
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+  }
+
+  .links > *:first-child {
+    margin-right: 8px; /* fix space between buy/share links */
+  }
+
+  .links > .logo {
+    line-height: 0;
+  }
+
+  .links > .logo > picture > img {
+    height: 32px;
+    width: 110px;
+  }
+</style>

--- a/src/Player.svelte
+++ b/src/Player.svelte
@@ -112,16 +112,6 @@
     cursor: auto;
     opacity: 0.5;
   }
-  a {
-    color: #537d86;
-    text-decoration: underline;
-    font-weight: 700;
-  }
-  @media (prefers-color-scheme: dark) {
-    a {
-      color: inherit;
-    }
-  }
 
   .player {
     display: flex;

--- a/src/Player.svelte
+++ b/src/Player.svelte
@@ -1,0 +1,164 @@
+<script>
+  export let toggle;
+  export let artwork;
+  export let album;
+  export let albumUrl;
+  export let tracks;
+  export let currentTrack;
+  export let startingTrack;
+  export let paused;
+  export let play;
+  export let pause;
+  export let seekingTime;
+  export let currentTime;
+  export let handleSeeking;
+  export let previousTrack;
+  export let nextTrack;
+
+  import playIcon from "./icons/play.svg";
+  import pauseIcon from "./icons/pause.svg";
+  import previousIcon from "./icons/previous.svg";
+  import nextIcon from "./icons/next.svg";
+</script>
+
+<div class="player">
+  <div class="artwork">
+    <img on:click={toggle} src={artwork} alt="Cover artwork for {album}" />
+  </div>
+  <div class="info">
+    <p>
+      <a href={albumUrl}>
+        {@html tracks[currentTrack === undefined ? startingTrack : currentTrack]
+          .title}
+      </a>
+    </p>
+    <p>
+      {@html tracks[currentTrack === undefined ? startingTrack : currentTrack]
+        .artist}
+    </p>
+    <p>{@html album}</p>
+    <div class="controls">
+      {#if paused || currentTrack === undefined}
+        <button
+          aria-label="Play current song"
+          on:click={() =>
+            play(currentTrack === undefined ? startingTrack : currentTrack)}
+        >
+          {@html playIcon}
+        </button>
+      {:else}
+        <button aria-label="Pause current song" on:click={pause}>
+          {@html pauseIcon}
+        </button>
+      {/if}
+      <input
+        aria-label="Seek"
+        type="range"
+        min="0"
+        max={currentTrack === undefined
+          ? undefined
+          : Math.floor(tracks[currentTrack].duration)}
+        value={(seekingTime === undefined ? currentTime : seekingTime) || 0}
+        on:change={handleSeeking}
+        on:input={handleSeeking}
+      />
+      <button
+        aria-label="Play previous song"
+        on:click={() => play(previousTrack)}
+        disabled={previousTrack === undefined}
+      >
+        {@html previousIcon}
+      </button>
+      <button
+        aria-label="Play next song"
+        on:click={() => play(nextTrack)}
+        disabled={nextTrack === undefined}
+      >
+        {@html nextIcon}
+      </button>
+    </div>
+  </div>
+</div>
+
+<style>
+  button {
+    cursor: pointer;
+    opacity: 0.8;
+    color: inherit;
+    border: none;
+    background-color: unset;
+    padding: 4px;
+    line-height: 0;
+  }
+  button:hover {
+    opacity: 1;
+  }
+  button:disabled {
+    cursor: auto;
+    opacity: 0.5;
+  }
+  a {
+    color: #537d86;
+    text-decoration: underline;
+    font-weight: 700;
+  }
+  @media (prefers-color-scheme: dark) {
+    a {
+      color: inherit;
+    }
+  }
+
+  .player {
+    display: flex;
+    height: 120px;
+  }
+
+  .info {
+    flex: 1 1 0;
+    min-width: 198px;
+    padding: 12px 0 0;
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    overflow: hidden;
+  }
+  .info p {
+    margin: 0 8px 0 12px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .info > p:last-of-type {
+    font-style: italic;
+  }
+
+  .controls {
+    width: 100%;
+    box-sizing: border-box;
+    display: flex;
+    align-items: center;
+    padding-right: 4px; /* line up with links below */
+  }
+  .controls > *:first-child {
+    padding-left: 8px; /* keep space between play button/artwork interactive */
+  }
+  .controls > input {
+    cursor: grab;
+    flex-grow: 1;
+    width: 0; /* force smaller width on Firefox */
+  }
+  .controls > input:active {
+    cursor: grabbing;
+  }
+
+  .artwork {
+    cursor: pointer;
+    height: 120px;
+    width: 120px;
+    min-width: 80px;
+    display: flex;
+    justify-content: center;
+    overflow: hidden;
+  }
+</style>

--- a/src/Player.svelte
+++ b/src/Player.svelte
@@ -1,5 +1,4 @@
 <script>
-  export let toggle;
   export let artwork;
   export let album;
   export let albumUrl;
@@ -8,9 +7,8 @@
   export let paused;
   export let play;
   export let pause;
-  export let seekingTime;
+  export let seek;
   export let currentTime;
-  export let handleSeeking;
   export let previousTrack;
   export let nextTrack;
 
@@ -18,6 +16,29 @@
   import pauseIcon from "./icons/pause.svg";
   import previousIcon from "./icons/previous.svg";
   import nextIcon from "./icons/next.svg";
+
+  function toggle() {
+    if (paused) {
+      play(currentTrack);
+    } else {
+      pause();
+    }
+  }
+
+  let seekingTime;
+  function handleSeeking(event) {
+    switch (event.type) {
+      case "change":
+        seek(event.target.value);
+        seekingTime = undefined;
+        break;
+      case "input":
+        seekingTime = event.target.value;
+        break;
+      default:
+        break;
+    }
+  }
 </script>
 
 <div class="player">

--- a/src/Player.svelte
+++ b/src/Player.svelte
@@ -5,7 +5,6 @@
   export let albumUrl;
   export let tracks;
   export let currentTrack;
-  export let startingTrack;
   export let paused;
   export let play;
   export let pause;
@@ -28,21 +27,18 @@
   <div class="info">
     <p>
       <a href={albumUrl}>
-        {@html tracks[currentTrack === undefined ? startingTrack : currentTrack]
-          .title}
+        {@html tracks[currentTrack].title}
       </a>
     </p>
     <p>
-      {@html tracks[currentTrack === undefined ? startingTrack : currentTrack]
-        .artist}
+      {@html tracks[currentTrack].artist}
     </p>
     <p>{@html album}</p>
     <div class="controls">
-      {#if paused || currentTrack === undefined}
+      {#if paused}
         <button
           aria-label="Play current song"
-          on:click={() =>
-            play(currentTrack === undefined ? startingTrack : currentTrack)}
+          on:click={() => play(currentTrack)}
         >
           {@html playIcon}
         </button>
@@ -55,9 +51,7 @@
         aria-label="Seek"
         type="range"
         min="0"
-        max={currentTrack === undefined
-          ? undefined
-          : Math.floor(tracks[currentTrack].duration)}
+        max={Math.floor(tracks[currentTrack].duration)}
         value={(seekingTime === undefined ? currentTime : seekingTime) || 0}
         on:change={handleSeeking}
         on:input={handleSeeking}

--- a/src/Tracklist.svelte
+++ b/src/Tracklist.svelte
@@ -1,0 +1,63 @@
+<script>
+  export let tracks;
+  export let currentTrack;
+  export let play;
+  export let artist;
+</script>
+
+<ul class="tracks">
+  {#each tracks as track, i}
+    <li
+      tabindex={tracks[i].track_streaming ? 0 : -1}
+      class:now-playing={i === currentTrack}
+      class:unstreamable={!tracks[i].track_streaming}
+      on:click={() => tracks[i].track_streaming && play(i)}
+      on:keydown={(e) => {
+        if (tracks[i].track_streaming && e.key === " ") {
+          e.preventDefault();
+          play(i);
+        }
+      }}
+    >
+      <span>
+        {Math.floor(track.duration / 60)
+          .toString()
+          .padStart(2, " ")}:{Math.floor(track.duration % 60)
+          .toString()
+          .padStart(2, "0")}
+      </span>
+      {@html "  " + track.title}
+      {#if track.artist !== artist}– {track.artist}{/if}
+    </li>
+  {/each}
+</ul>
+
+<style>
+  .tracks {
+    margin: 8px 0 0;
+    padding: 0;
+    height: 160px;
+    overflow-y: scroll;
+  }
+  .tracks > * {
+    font-size: 12px;
+    cursor: pointer;
+    margin: 0px 12px;
+    padding: 10px 8px;
+    list-style-type: none;
+    border-bottom: 1px solid #bbb;
+    white-space: pre;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .tracks > .now-playing {
+    font-weight: 700;
+  }
+  .tracks > .unstreamable {
+    cursor: default;
+    opacity: 0.5;
+  }
+  .tracks span {
+    font-family: monospace;
+  }
+</style>

--- a/src/Tracklist.svelte
+++ b/src/Tracklist.svelte
@@ -2,7 +2,8 @@
   export let tracks;
   export let currentTrack;
   export let play;
-  export let artist;
+
+  $: artist = tracks[currentTrack].artist;
 </script>
 
 <ul class="tracks">

--- a/src/Tracklist.svelte
+++ b/src/Tracklist.svelte
@@ -14,7 +14,7 @@
       class:unstreamable={!tracks[i].track_streaming}
       on:click={() => tracks[i].track_streaming && play(i)}
       on:keydown={(e) => {
-        if (tracks[i].track_streaming && e.key === " ") {
+        if (tracks[i].track_streaming && (e.key === " " || e.key === "Enter")) {
           e.preventDefault();
           play(i);
         }


### PR DESCRIPTION
It's finally time to break up the 400 line `App.svelte` file into smaller components. This also gives the opportunity to fix some existing annoyances:
 * No need for both a  `startingTrack` and a `currentTrack`
 * Component-specific logic (`handleSeeking()`, derived values like album artist) can be shifted down, out of the main file