### PR TITLE
Refactor worker, add hapi/handlebars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 node_modules/
-src/worker/embed/
+src/worker/templates/*.hbs.js
 dist/

--- a/build.js
+++ b/build.js
@@ -1,0 +1,19 @@
+const cp = require("child_process");
+const fs = require("fs");
+
+console.log("--- Building Svelte embed");
+cp.execSync("rollup -c");
+
+console.log("--- Precompiling Handlebars templates");
+fs.mkdirSync("dist/templates/", { recursive: true });
+cp.execSync(
+  "handlebars src/worker/templates/home.hbs -f dist/templates/home.hbs.js"
+);
+cp.execSync(
+  "handlebars src/worker/templates/embed.hbs -f dist/templates/embed.hbs.js"
+);
+
+console.log("--- Bundling worker code");
+cp.execSync(
+  "esbuild src/worker/main.js --bundle --loader:.html=text --external:fs --outfile=dist/main.js"
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -365,6 +365,25 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
+    "handlebars": {
+      "version": "4.7.7",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
+      "requires": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.0",
+        "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4",
+        "wordwrap": "^1.0.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        }
+      }
+    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -458,6 +477,11 @@
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+    },
+    "neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
     },
     "path-parse": {
       "version": "1.0.7",
@@ -634,6 +658,12 @@
         "source-map-support": "~0.5.19"
       }
     },
+    "uglify-js": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.14.2.tgz",
+      "integrity": "sha512-rtPMlmcO4agTUfz10CbgJ1k6UAoXM2gWb3GoMPPZB/+/Ackf8lNWk11K4rYi2D0apgoFRLtQOZhb+/iGNJq26A==",
+      "optional": true
+    },
     "uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -641,6 +671,11 @@
       "requires": {
         "punycode": "^2.1.0"
       }
+    },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -190,6 +190,19 @@
         }
       }
     },
+    "@hapi/boom": {
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.4.tgz",
+      "integrity": "sha512-Ls1oH8jaN1vNsqcaHVYJrKmgMcKsC1wcp8bujvXrHaAqD2iDYq3HoOwsxwo09Cuda5R5nC0o0IxlrlTuvPuzSw==",
+      "requires": {
+        "@hapi/hoek": "9.x.x"
+      }
+    },
+    "@hapi/hoek": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.0.tgz",
+      "integrity": "sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug=="
+    },
     "@rollup/plugin-image": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-image/-/plugin-image-2.1.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -198,6 +198,15 @@
         "@hapi/hoek": "9.x.x"
       }
     },
+    "@hapi/call": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/call/-/call-8.0.1.tgz",
+      "integrity": "sha512-bOff6GTdOnoe5b8oXRV3lwkQSb/LAWylvDMae6RgEWWntd0SHtkYbQukDHKlfaYtVnSAgIavJ0kqszF/AIBb6g==",
+      "requires": {
+        "@hapi/boom": "9.x.x",
+        "@hapi/hoek": "9.x.x"
+      }
+    },
     "@hapi/hoek": {
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "version": "1.0.0",
   "main": "dist/main.js",
   "scripts": {
-    "build": "rollup -c && esbuild src/worker/main.js --bundle --loader:.html=text --outfile=dist/main.js",
+    "build": "node build.js",
     "dev": "wrangler dev",
     "deploy": "NODE_ENV=production wrangler publish",
     "login": "wrangler login"
@@ -15,6 +15,7 @@
     "@rollup/plugin-image": "^2.1.1",
     "@rollup/plugin-node-resolve": "^13.0.4",
     "esbuild": "^0.12.26",
+    "handlebars": "^4.7.7",
     "raw-loader": "^4.0.2",
     "rollup": "^2.56.3",
     "rollup-plugin-css-only": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@cloudflare/wrangler": "^1.19.2",
     "@hapi/boom": "^9.1.4",
+    "@hapi/call": "^8.0.1",
     "@rollup/plugin-image": "^2.1.1",
     "@rollup/plugin-node-resolve": "^13.0.4",
     "esbuild": "^0.12.26",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@cloudflare/wrangler": "^1.19.2",
+    "@hapi/boom": "^9.1.4",
     "@rollup/plugin-image": "^2.1.1",
     "@rollup/plugin-node-resolve": "^13.0.4",
     "esbuild": "^0.12.26",

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -53,7 +53,7 @@
   async function load() {
     try {
       const response = await fetch(
-        `${origin}/embed-data?album=${encodeURIComponent(albumId)}`
+        `${origin}/album/${encodeURIComponent(albumId)}`
       ).then(async (r) => {
         if (r.status !== 200) {
           throw new Error(await r.text());

--- a/src/worker/bandcamp.js
+++ b/src/worker/bandcamp.js
@@ -1,0 +1,75 @@
+module.exports = {
+  getAlbumPlayerData,
+  getAlbumDetails,
+};
+
+/**
+ * Requests embed data about an album from the Bandcamp embed endpoint.
+ *
+ * Details like referrer and client IP aren't strictly necessary, but keeping
+ * them helps stay faithful to the behaviour of Bandcamp's native embed.
+ *
+ * TODO: Should allowed origins (referrers) be restricted?
+ */
+async function getAlbumPlayerData(albumId, clientIP, referrer) {
+  // Form a request with the necessary shape
+  const request = new Request(
+    `https://bandcamp.com/EmbeddedPlayer/ref=${encodeURIComponent(
+      referrer
+    )}/album=${albumId}`
+  );
+  request.headers.set("X-Forwarded-For", clientIP);
+  request.headers.set("Forwarded", `for=${clientIP}`);
+
+  const response = await fetch(request);
+  if (response.status !== 200) {
+    throw new Error(`Received ${response.status} from Bandcamp`);
+  }
+  const text = await response.text();
+
+  // Player data is stored as a data attribute in the document... hmm...
+  const match = text.match(/data-player-data="([^"]*)"/);
+  if (match === null) {
+    throw new Error("Could not read player data from Bandcamp");
+  }
+  return match[1].replace(/&quot;/g, '"');
+}
+
+/**
+ * Albums in a Bandcamp embed are loaded by their ID, rather than a URL/name.
+ * Unfortunately these IDs are not easily available to regular users.
+ *
+ * Similarly, an album's title ("{{album}}, by {{artist}}") is used as a
+ * placeholder for the embed when it fails to load and for noscript users. It
+ * needs to be available in the embed snippet.
+ *
+ * Both of these problems can be solved by requesting the URL of the album in
+ * question, and parsing the response to find these values. Parsing HTML with
+ * text matching is fairly janky, but its workable with these small queries.
+ */
+async function getAlbumDetails(url) {
+  let response = await fetch(url);
+  if (response.status !== 200) {
+    throw new Error(`Received ${response.status} from Bandcamp`);
+  }
+  const text = await response.text();
+
+  let albumId;
+  const matchAlbumId = text.match(/<!-- album id ([0-9]*) -->\n$/);
+  if (matchAlbumId === null) {
+    throw new Error("Could not find album ID");
+  }
+  albumId = matchAlbumId[1];
+
+  let title;
+  let matchTitle = text.match(/<meta name="title" content="(.*)">/);
+  if (matchTitle === null) {
+    throw new Error("Could not find album title");
+  }
+  title = matchTitle[1];
+
+  return {
+    albumId,
+    title,
+  };
+}

--- a/src/worker/bandcamp.js
+++ b/src/worker/bandcamp.js
@@ -1,3 +1,5 @@
+const Boom = require("@hapi/boom");
+
 module.exports = {
   getAlbumPlayerData,
   getAlbumDetails,
@@ -23,14 +25,14 @@ async function getAlbumPlayerData(albumId, clientIP, referrer) {
 
   const response = await fetch(request);
   if (response.status !== 200) {
-    throw new Error(`Received ${response.status} from Bandcamp`);
+    throw Boom.internal(`Received ${response.status} from Bandcamp`);
   }
   const text = await response.text();
 
   // Player data is stored as a data attribute in the document... hmm...
   const match = text.match(/data-player-data="([^"]*)"/);
   if (match === null) {
-    throw new Error("Could not read player data from Bandcamp");
+    throw Boom.internal("Could not read player data from Bandcamp");
   }
   return match[1].replace(/&quot;/g, '"');
 }
@@ -50,21 +52,21 @@ async function getAlbumPlayerData(albumId, clientIP, referrer) {
 async function getAlbumDetails(url) {
   let response = await fetch(url);
   if (response.status !== 200) {
-    throw new Error(`Received ${response.status} from Bandcamp`);
+    throw Boom.internal(`Received ${response.status} from Bandcamp`);
   }
   const text = await response.text();
 
   let albumId;
   const matchAlbumId = text.match(/<!-- album id ([0-9]*) -->\n$/);
   if (matchAlbumId === null) {
-    throw new Error("Could not find album ID");
+    throw Boom.internal("Could not find album ID");
   }
   albumId = matchAlbumId[1];
 
   let title;
   let matchTitle = text.match(/<meta name="title" content="(.*)">/);
   if (matchTitle === null) {
-    throw new Error("Could not find album title");
+    throw Boom.internal("Could not find album title");
   }
   title = matchTitle[1];
 

--- a/src/worker/main.js
+++ b/src/worker/main.js
@@ -1,9 +1,19 @@
+/**
+ * A dependency of boom/call, hoek, references Node's Buffer API. Cloudflare
+ * rejects workers whose code references this unavailable API. Declaring a falsy
+ * value via an implicit global gets around this behaviour.
+ */
 Buffer = undefined;
 const Boom = require("@hapi/boom");
 const Call = require("@hapi/call");
 
 const bandcamp = require("./bandcamp.js");
 
+/**
+ * To get Handlebars to run on a worker (without Webpack's handlebars-loader),
+ * either the global or window APIs need to be available. Using an implicit
+ * global achieves this, even if it janky.
+ */
 global = {};
 Handlebars = require("handlebars");
 require("../../dist/templates/embed.hbs.js");

--- a/src/worker/main.js
+++ b/src/worker/main.js
@@ -1,5 +1,10 @@
 // TODO: Use Boom for error responses
 
+global = {};
+Handlebars = require("handlebars");
+require("../../dist/templates/embed.hbs.js");
+require("../../dist/templates/home.hbs.js");
+
 addEventListener("fetch", (event) => {
   event.respondWith(handleRequest(event));
 });
@@ -93,7 +98,7 @@ async function getEmbedData(event) {
 
 async function getEmbed(event) {
   const url = new URL(event.request.url).searchParams.get("url");
-  let embed = "";
+  let embed;
   if (url !== null) {
     let { origin } = new URL(event.request.url);
     embed = await generateEmbed(url, origin);
@@ -127,77 +132,14 @@ async function generateEmbed(url, origin) {
   }
   title = matchTitle[1];
 
-  return `<!-- bandcamp-mini-embed https://github.com/nchlswhttkr/bandcamp-mini-embed -->
-<link rel="stylesheet" href="${origin}/embed/bundle.css"/>
-<div class="bandcamp-mini-embed" style="height: 336px"></div>
-<script
-    data-album-id="${albumId}"
-    data-fallback-text="${title}"
-    data-fallback-url="${url}"
-    src="${origin}/embed/bundle.js"
-></script>
-<noscript>
-    <a href="${url}">Listen to ${title} on Bandcamp</a>
-</noscript>
-`;
+  return Handlebars.templates["embed.hbs"]({
+    origin,
+    albumId,
+    title,
+    url,
+  });
 }
 
 function generateResponse(embed) {
-  return `
-  <!DOCTYPE html>
-  <html lang="en">
-      <head>
-      <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-      <title>bandcamp-mini-embed</title>
-      <meta charset="utf-8" />
-      <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-      <style>
-          main { color: #333; margin: 0 auto; max-width: 800px; font-family: monospace; }
-  
-          h1, p { text-align: center; }
-  
-          label { display: flex; justify-content: center; align-items: center; }
-  
-          input { margin-left: 8px; }
-  
-          button { display: block; margin: 16px auto; background-color: #fff; font-family: monospace; padding: 4px; border: 2px solid #333; }
-  
-          pre { background-color: #333; color: #fff; padding: 8px; line-height: 1.2rem; overflow-x: scroll; }
-  
-          .bandcamp-mini-embed { max-width: 400px; margin: 0 auto; }
-      </style>
-      </head>
-      <body>
-      <main>
-          <h1>bandcamp-mini-embed</h1>
-          <p>A music player embed for <a href="https://bandcamp.com/">Bandcamp</a> albums</p>
-          <form>
-              <label>Album URL <input type="text" name="url" /></label>
-              <button>Generate embed</button>
-          </form>
-          ${
-            embed &&
-            `
-              <pre><code id="embed-snippet">${embed
-                .replace(/&/g, "&amp;")
-                .replace(/</g, "&lt;")
-                .replace(/>/g, "&gt;")}</code></pre>
-              <button onclick="copyEmbed()">Copy embed</button>
-              ${embed}
-              <script>
-                  function copyEmbed() {
-                      navigator.clipboard.writeText(document.getElementById("embed-snippet").innerText);
-                  }
-              </script>
-              `
-          }
-          <p>
-              <a href="https://github.com/nchlswhttkr/bandcamp-mini-embed">Source code</a>
-              &bull;
-              <a href="/examples/">Example albums</a>
-          </p>
-      </main>
-      </body>
-  </html>  
-  `;
+  return Handlebars.templates["home.hbs"]({ embed });
 }

--- a/src/worker/main.js
+++ b/src/worker/main.js
@@ -100,8 +100,7 @@ async function getEmbed(event) {
   const url = new URL(event.request.url).searchParams.get("url");
   let embed;
   if (url !== null) {
-    let { origin } = new URL(event.request.url);
-    embed = await generateEmbed(url, origin);
+    embed = await generateEmbed(url);
   }
 
   return new Response(generateResponse(embed), {
@@ -110,7 +109,7 @@ async function getEmbed(event) {
   });
 }
 
-async function generateEmbed(url, origin) {
+async function generateEmbed(url) {
   let text = await fetch(url).then((r) => {
     if (r.status !== 200) {
       throw new Error(`Received ${r.status} from Bandcamp`);
@@ -133,7 +132,6 @@ async function generateEmbed(url, origin) {
   title = matchTitle[1];
 
   return Handlebars.templates["embed.hbs"]({
-    origin,
     albumId,
     title,
     url,

--- a/src/worker/templates/embed.hbs
+++ b/src/worker/templates/embed.hbs
@@ -1,10 +1,10 @@
 <!-- bandcamp-mini-embed https://github.com/nchlswhttkr/bandcamp-mini-embed -->
-<link rel="stylesheet" href="{{origin}}/embed/bundle.css"/>
+<link rel="stylesheet" href="__EMBED_ORIGIN__/embed/bundle.css"/>
 <div class="bandcamp-mini-embed" style="height: 336px"></div>
 <script
     data-album-id="{{albumId}}"
     data-fallback-text="{{title}}"
     data-fallback-url="{{url}}"
-    src="{{origin}}/embed/bundle.js"
+    src="__EMBED_ORIGIN__/embed/bundle.js"
 ></script>
 <noscript><a href="{{albumUrl}}">Listen to {{title}} on Bandcamp</a></noscript>

--- a/src/worker/templates/embed.hbs
+++ b/src/worker/templates/embed.hbs
@@ -1,0 +1,10 @@
+<!-- bandcamp-mini-embed https://github.com/nchlswhttkr/bandcamp-mini-embed -->
+<link rel="stylesheet" href="{{origin}}/embed/bundle.css"/>
+<div class="bandcamp-mini-embed" style="height: 336px"></div>
+<script
+    data-album-id="{{albumId}}"
+    data-fallback-text="{{title}}"
+    data-fallback-url="{{url}}"
+    src="{{origin}}/embed/bundle.js"
+></script>
+<noscript><a href="{{albumUrl}}">Listen to {{title}} on Bandcamp</a></noscript>

--- a/src/worker/templates/home.hbs
+++ b/src/worker/templates/home.hbs
@@ -24,12 +24,8 @@
     <body>
     <main>
         <h1>bandcamp-mini-embed</h1>
-        <p>A music player embed for <a href="https://bandcamp.com/">Bandcamp</a> albums</p>
-        <form>
-            <label>Album URL <input type="text" name="url" /></label>
-            <button>Generate embed</button>
-        </form>
         {{#if embed}}
+            <p>Here's your embed, you can copy the code for it below!</p>
             <button onclick="copyEmbed()">Copy embed</button>
             <div id="embed-target"></div>
             <pre><code id="embed-snippet"></code></pre>
@@ -51,6 +47,12 @@
                     navigator.clipboard.writeText(document.getElementById("embed-snippet").innerText);
                 }
             </script>
+        {{else}}
+        <p>A music player embed for <a href="https://bandcamp.com/">Bandcamp</a> albums</p>
+        <form>
+            <label>Album URL <input type="text" name="url" /></label>
+            <button>Generate embed</button>
+        </form>
         {{/if}}
         <p>
             <a href="https://github.com/nchlswhttkr/bandcamp-mini-embed">Source code</a>

--- a/src/worker/templates/home.hbs
+++ b/src/worker/templates/home.hbs
@@ -1,52 +1,86 @@
 <!DOCTYPE html>
 <html lang="en">
-    <head>
+
+<head>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
     <title>bandcamp-mini-embed</title>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <style>
-        main { color: #333; margin: 0 auto; max-width: 800px; font-family: monospace; }
+        main {
+            color: #333;
+            margin: 0 auto;
+            max-width: 800px;
+            font-family: monospace;
+        }
 
-        h1, p { text-align: center; }
+        h1,
+        p {
+            text-align: center;
+        }
 
-        label { display: flex; justify-content: center; align-items: center; }
+        label {
+            display: flex;
+            justify-content: center;
+            align-items: center;
+        }
 
-        input { margin-left: 8px; }
+        input {
+            margin-left: 8px;
+            border: 1px solid #000
+        }
 
-        button { display: block; margin: 16px auto; background-color: #fff; font-family: monospace; padding: 4px; border: 2px solid #333; }
+        button {
+            display: block;
+            margin: 16px auto;
+            background-color: #fff;
+            font-family: monospace;
+            padding: 8px;
+            border: 2px solid #333;
+            cursor: pointer
+        }
 
-        pre { background-color: #333; color: #fff; padding: 8px; line-height: 1.2rem; overflow-x: scroll; }
+        pre {
+            background-color: #333;
+            color: #fff;
+            padding: 8px;
+            line-height: 1.2rem;
+            overflow-x: scroll;
+        }
 
-        .bandcamp-mini-embed { max-width: 400px; margin: 0 auto; }
+        .bandcamp-mini-embed {
+            max-width: 400px;
+            margin: 0 auto;
+        }
     </style>
-    </head>
-    <body>
+</head>
+
+<body>
     <main>
         <h1>bandcamp-mini-embed</h1>
         {{#if embed}}
-            <p>Here's your embed, you can copy the code for it below!</p>
-            <button onclick="copyEmbed()">Copy embed</button>
-            <div id="embed-target"></div>
-            <pre><code id="embed-snippet"></code></pre>
-            <script>
-                const embed = `{{embed}}`.replace(/__EMBED_ORIGIN__/g, new URL(window.location).origin)
-                document.getElementById('embed-snippet').innerHTML = embed
-                const target = document.getElementById('embed-target')
-                target.innerHTML = document.getElementById('embed-snippet').innerText
+        <p>Here's your embed, you can copy the code for it below!</p>
+        <button onclick="copyEmbed()">Copy embed</button>
+        <div id="embed-target"></div>
+        <pre><code id="embed-snippet"></code></pre>
+        <script>
+            const embed = `{{embed}}`.replace(/__EMBED_ORIGIN__/g, new URL(window.location).origin)
+            document.getElementById('embed-snippet').innerHTML = embed
+            const target = document.getElementById('embed-target')
+            target.innerHTML = document.getElementById('embed-snippet').innerText
 
-                const script = Array.from(target.children).find(element => element.tagName === "SCRIPT")
-                const replacement = document.createElement('script')
-                for (let i = 0; i < script.attributes.length; i++) {
-                    const attribute = script.attributes.item(i)
-                    replacement.setAttribute(attribute.name, attribute.value)
-                }
-                target.replaceChild(replacement, script)
+            const script = Array.from(target.children).find(element => element.tagName === "SCRIPT")
+            const replacement = document.createElement('script')
+            for (let i = 0; i < script.attributes.length; i++) {
+                const attribute = script.attributes.item(i)
+                replacement.setAttribute(attribute.name, attribute.value)
+            }
+            target.replaceChild(replacement, script)
 
-                function copyEmbed() {
-                    navigator.clipboard.writeText(document.getElementById("embed-snippet").innerText);
-                }
-            </script>
+            function copyEmbed() {
+                navigator.clipboard.writeText(document.getElementById("embed-snippet").innerText);
+            }
+        </script>
         {{else}}
         <p>A music player embed for <a href="https://bandcamp.com/">Bandcamp</a> albums</p>
         <form>
@@ -60,5 +94,6 @@
             <a href="/examples/">Example albums</a>
         </p>
     </main>
-    </body>
+</body>
+
 </html>

--- a/src/worker/templates/home.hbs
+++ b/src/worker/templates/home.hbs
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+    <title>bandcamp-mini-embed</title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <style>
+        main { color: #333; margin: 0 auto; max-width: 800px; font-family: monospace; }
+
+        h1, p { text-align: center; }
+
+        label { display: flex; justify-content: center; align-items: center; }
+
+        input { margin-left: 8px; }
+
+        button { display: block; margin: 16px auto; background-color: #fff; font-family: monospace; padding: 4px; border: 2px solid #333; }
+
+        pre { background-color: #333; color: #fff; padding: 8px; line-height: 1.2rem; overflow-x: scroll; }
+
+        .bandcamp-mini-embed { max-width: 400px; margin: 0 auto; }
+    </style>
+    </head>
+    <body>
+    <main>
+        <h1>bandcamp-mini-embed</h1>
+        <p>A music player embed for <a href="https://bandcamp.com/">Bandcamp</a> albums</p>
+        <form>
+            <label>Album URL <input type="text" name="url" /></label>
+            <button>Generate embed</button>
+        </form>
+        {{#if embed}}
+            <pre><code id="embed-snippet">{{embed}}</code></pre>
+            <button onclick="copyEmbed()">Copy embed</button>
+            {{{embed}}}
+            <script>
+                function copyEmbed() {
+                    navigator.clipboard.writeText(document.getElementById("embed-snippet").innerText);
+                }
+            </script>
+        {{/if}}
+        <p>
+            <a href="https://github.com/nchlswhttkr/bandcamp-mini-embed">Source code</a>
+            &bull;
+            <a href="/examples/">Example albums</a>
+        </p>
+    </main>
+    </body>
+</html>

--- a/src/worker/templates/home.hbs
+++ b/src/worker/templates/home.hbs
@@ -30,10 +30,23 @@
             <button>Generate embed</button>
         </form>
         {{#if embed}}
-            <pre><code id="embed-snippet">{{embed}}</code></pre>
             <button onclick="copyEmbed()">Copy embed</button>
-            {{{embed}}}
+            <div id="embed-target"></div>
+            <pre><code id="embed-snippet"></code></pre>
             <script>
+                const embed = `{{embed}}`.replace(/__EMBED_ORIGIN__/g, new URL(window.location).origin)
+                document.getElementById('embed-snippet').innerHTML = embed
+                const target = document.getElementById('embed-target')
+                target.innerHTML = document.getElementById('embed-snippet').innerText
+
+                const script = Array.from(target.children).find(element => element.tagName === "SCRIPT")
+                const replacement = document.createElement('script')
+                for (let i = 0; i < script.attributes.length; i++) {
+                    const attribute = script.attributes.item(i)
+                    replacement.setAttribute(attribute.name, attribute.value)
+                }
+                target.replaceChild(replacement, script)
+
                 function copyEmbed() {
                     navigator.clipboard.writeText(document.getElementById("embed-snippet").innerText);
                 }

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -5,4 +5,4 @@ workers_dev = true
 
 [build]
 upload.format = "service-worker"
-command = "npm run build" 
+command = "node build.js"


### PR DESCRIPTION
* Add `@hapi/call` and `@hapi/boom` for better routing and error handling
* Split off HTML snippets/responses from the main worker code into handlebars templates
* Tidy up and document the various functions and subrequests the worker makes

Unfortunately there's still a bit of jank in getting handlebars and hapi libraries to run on Cloudflare Workers. These are mostly products of Cloudflare's custom runtime.
* Templates need to be precompiled, since `eval` is disallowed
* Some browser/Node-specific APIs (`global`/`window`/`Buffer`) need to be mocked with dummy values, otherwise `ReferenceError`s will crop up when the worker is run